### PR TITLE
feat: add collapsible node groups

### DIFF
--- a/src/react/packages/funcnodes-react-flow/src/core/funcnodes-context/handler/rf-manager.ts
+++ b/src/react/packages/funcnodes-react-flow/src/core/funcnodes-context/handler/rf-manager.ts
@@ -91,11 +91,33 @@ export class ReactFlowManagerHandler
     ) {
       return;
     }
+    const sourceMapping =
+      this.nodespaceManager.get_collapsed_handle_mapping(
+        connection.source,
+        connection.sourceHandle
+      );
+    const targetMapping =
+      this.nodespaceManager.get_collapsed_handle_mapping(
+        connection.target,
+        connection.targetHandle
+      );
+    const finalSource = sourceMapping
+      ? sourceMapping.nodeId
+      : connection.source;
+    const finalSourceHandle = sourceMapping
+      ? sourceMapping.ioId
+      : connection.sourceHandle;
+    const finalTarget = targetMapping
+      ? targetMapping.nodeId
+      : connection.target;
+    const finalTargetHandle = targetMapping
+      ? targetMapping.ioId
+      : connection.targetHandle;
     this.workerManager.worker.api.edge.add_edge({
-      src_nid: connection.source,
-      src_ioid: connection.sourceHandle,
-      trg_nid: connection.target,
-      trg_ioid: connection.targetHandle,
+      src_nid: finalSource,
+      src_ioid: finalSourceHandle,
+      trg_nid: finalTarget,
+      trg_ioid: finalTargetHandle,
       replace: true,
     });
   };

--- a/src/react/packages/funcnodes-react-flow/src/features/groups/components/groups.scss
+++ b/src/react/packages/funcnodes-react-flow/src/features/groups/components/groups.scss
@@ -53,6 +53,167 @@
   }
 }
 
+.fn-group .fn-group-toggle {
+  display: none;
+  position: absolute;
+  top: 6px;
+  left: 10px;
+  width: 20px;
+  height: 20px;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  font-weight: bold;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 2;
+  line-height: 18px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  &:hover {
+    background: rgba(0, 0, 0, 0.3);
+  }
+}
+
 .selected .fn-group .fn-group-remove {
   display: flex;
+}
+
+.selected .fn-group .fn-group-toggle {
+  display: flex;
+}
+
+.fn-group-collapsed-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+
+.fn-group-collapsed {
+  width: 100%;
+  min-width: 200px;
+  max-width: 280px;
+  border-radius: var(--node_border_radius);
+  border: var(--node_border_width) solid
+    var(--fn-node-border-color, rgba(255, 255, 255, 0.12));
+  background-color: var(--fn-node-background);
+  color: var(--fn-text-color-neutral);
+  box-shadow: var(--fn-node-shadow, 0 6px 24px rgba(0, 0, 0, 0.35));
+}
+
+.fn-group-collapsed .innernode {
+  min-height: 0;
+}
+
+.fn-group-collapsed__button {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.fn-group-collapsed__button:hover {
+  color: var(--fn-primary-color, #0cc3f5);
+}
+
+.fn-group-collapsed__body {
+  padding: var(--fn-space-xs, 0.35rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fn-space-xs, 0.25rem);
+}
+
+.fn-group-collapsed__columns {
+  display: flex;
+  gap: var(--fn-space-xs, 0.25rem);
+}
+
+.fn-group-collapsed__column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--fn-space-xxs, 0.2rem);
+  min-width: 0;
+}
+
+.fn-group-collapsed__column--inputs {
+  align-items: flex-start;
+}
+
+.fn-group-collapsed__column--outputs {
+  align-items: flex-end;
+}
+
+.fn-group-collapsed__empty {
+  padding: var(--fn-space-xs, 0.35rem);
+  text-align: center;
+  font-size: var(--fn-font-size-xs, 0.75rem);
+  color: var(--fn-text-color-muted, rgba(255, 255, 255, 0.65));
+}
+
+.fn-group-io {
+  display: flex;
+  align-items: center;
+  gap: var(--fn-space-xxs, 0.25rem);
+  padding: 0.2rem 0.3rem;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  min-width: 0;
+  width: 100%;
+}
+
+.fn-group-io__label {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.fn-group-io--input .fn-group-io__label {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.fn-group-io--output .fn-group-io__label {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.fn-group-io__label-node {
+  font-weight: 600;
+  font-size: var(--fn-font-size-xs, 0.75rem);
+  line-height: 1.1;
+}
+
+.fn-group-io__label-name {
+  font-size: 0.7rem;
+  color: var(--fn-text-color-muted, rgba(255, 255, 255, 0.7));
+  line-height: 1.1;
+}
+
+.fn-group-io__badge {
+  align-self: flex-start;
+  margin-top: 0.2rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background-color: var(--fn-primary-color, #0cc3f5);
+  color: #000;
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+
+.fn-group-io--output .fn-group-io__badge {
+  align-self: flex-end;
+}
+
+.fn-group-io__handle {
+  flex: 0 0 auto;
 }

--- a/src/react/packages/funcnodes-react-flow/src/features/groups/components/index.tsx
+++ b/src/react/packages/funcnodes-react-flow/src/features/groups/components/index.tsx
@@ -1,13 +1,29 @@
 import * as React from "react";
 import { useRemoveGroups } from "../hooks";
-import { CloseIcon } from "@/icons";
+import { CloseIcon, ChevronDownIcon, ChevronUpIcon } from "@/icons";
 import "./groups.scss";
+import { Handle, Position } from "@xyflow/react";
+import { useFuncNodesContext } from "@/providers";
+import { useWorkerApi } from "@/workers";
+import { GroupActionUpdate } from "@/funcnodes-context";
+import {
+  CollapsedGroupVisualState,
+  CollapsedGroupIO,
+  GroupRFNodeData,
+} from "@/nodes";
+
+export interface NodeGroupMeta {
+  collapsed?: boolean;
+  name?: string;
+  label?: string;
+  [key: string]: any;
+}
 
 export interface NodeGroup {
   node_ids: string[];
   child_groups: string[];
   parent_group: string | null;
-  meta: Record<string, any>;
+  meta: NodeGroupMeta;
   position: [number, number];
 }
 
@@ -16,9 +32,20 @@ export interface NodeGroups {
 }
 
 // The default Node rendering component for groups
-export const DefaultGroup = ({ data }: { data: any }) => {
+export const DefaultGroup = ({ data }: { data: GroupRFNodeData }) => {
   const groupId = data?.group?.id || data?.id;
   const removeGroups = useRemoveGroups();
+  const fnrf = useFuncNodesContext();
+  const { group: groupApi } = useWorkerApi();
+
+  const collapsed = data?.collapsed ?? data?.group?.meta?.collapsed ?? false;
+  const collapsedInfo: CollapsedGroupVisualState = data?.collapsedInfo ?? {
+    inputs: [],
+    outputs: [],
+  };
+  const label =
+    data?.group?.meta?.name || data?.group?.meta?.label || groupId || "Group";
+
   const handleRemove = React.useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -28,8 +55,147 @@ export const DefaultGroup = ({ data }: { data: any }) => {
     },
     [groupId, removeGroups]
   );
+
+  const toggleCollapsed = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!groupId) {
+        return;
+      }
+      const next = !collapsed;
+      const update: GroupActionUpdate = {
+        type: "update",
+        id: groupId,
+        group: { meta: { collapsed: next } },
+        from_remote: true,
+      };
+      fnrf.on_group_action(update);
+      const workerUpdate: GroupActionUpdate = {
+        ...update,
+        from_remote: false,
+        immediate: true,
+      };
+      groupApi?.locally_update_group(workerUpdate);
+    },
+    [collapsed, fnrf, groupApi, groupId]
+  );
+
+  const renderIoRow = React.useCallback(
+    (io: CollapsedGroupIO, direction: "input" | "output") => {
+      const isInput = direction === "input";
+      const connectionLabel =
+        io.connectionCount > 0
+          ? `${io.connectionCount} connection${
+              io.connectionCount > 1 ? "s" : ""
+            }`
+          : undefined;
+      return (
+        <div
+          key={io.handleId}
+          className={`fn-group-io fn-group-io--${direction}`}
+          title={`${io.nodeName} • ${io.ioName}`}
+        >
+          {isInput ? (
+            <Handle
+              id={io.handleId}
+              type="target"
+              position={Position.Left}
+              className="fn-group-io__handle"
+              data-type={io.type}
+            />
+          ) : null}
+          <div className="fn-group-io__label">
+            <span className="fn-group-io__label-node">{io.nodeName}</span>
+            <span className="fn-group-io__label-name">{io.ioName}</span>
+            {io.connectionCount > 0 ? (
+              <span
+                className="fn-group-io__badge"
+                title={connectionLabel}
+                aria-label={connectionLabel}
+              >
+                {io.connectionCount}
+              </span>
+            ) : null}
+          </div>
+          {!isInput ? (
+            <Handle
+              id={io.handleId}
+              type="source"
+              position={Position.Right}
+              className="fn-group-io__handle"
+              data-type={io.type}
+            />
+          ) : null}
+        </div>
+      );
+    },
+    []
+  );
+
+  if (collapsed) {
+    const hasInputs = collapsedInfo.inputs.length > 0;
+    const hasOutputs = collapsedInfo.outputs.length > 0;
+    const hasIo = hasInputs || hasOutputs;
+    return (
+      <div className="fn-group-collapsed-wrapper">
+        <div className="fn-group-collapsed react-flow__node-default">
+          <div className="innernode">
+            <div className="nodeheader">
+              <div className="nodeheader_element">
+                <button
+                  className="nodeheaderbutton fn-group-collapsed__button"
+                  onClick={toggleCollapsed}
+                  title="Expand group"
+                >
+                  <ChevronDownIcon />
+                </button>
+              </div>
+              <div className="nodeheader_element nodeheader_title">
+                <div className="nodeheader_title_text">{label}</div>
+              </div>
+              <div className="nodeheader_element">
+                <button
+                  className="nodeheaderbutton fn-group-collapsed__button"
+                  onClick={handleRemove}
+                  title="Remove group"
+                >
+                  <CloseIcon />
+                </button>
+              </div>
+            </div>
+            <div className="nodebody fn-group-collapsed__body">
+              {hasIo ? (
+                <div className="fn-group-collapsed__columns">
+                  <div className="fn-group-collapsed__column fn-group-collapsed__column--inputs">
+                    {collapsedInfo.inputs.map((io) =>
+                      renderIoRow(io, "input")
+                    )}
+                  </div>
+                  <div className="fn-group-collapsed__column fn-group-collapsed__column--outputs">
+                    {collapsedInfo.outputs.map((io) =>
+                      renderIoRow(io, "output")
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="fn-group-collapsed__empty">No exposed IOs</div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="fn-group">
+      <button
+        className="fn-group-toggle"
+        title="Collapse group"
+        onClick={toggleCollapsed}
+      >
+        <ChevronUpIcon />
+      </button>
       <button
         className="fn-group-remove"
         title="Remove group"
@@ -37,7 +203,7 @@ export const DefaultGroup = ({ data }: { data: any }) => {
       >
         <CloseIcon />
       </button>
-      Group
+      {label}
     </div>
   );
 };

--- a/src/react/packages/funcnodes-react-flow/src/features/nodes/index.ts
+++ b/src/react/packages/funcnodes-react-flow/src/features/nodes/index.ts
@@ -5,6 +5,8 @@ export type {
   GroupRFNode,
   DefaultRFNode,
   AnyFuncNodesRFNode,
+  CollapsedGroupIO,
+  CollapsedGroupVisualState,
 } from "./rf-node-types";
 
 export { NodeContext, useNodeStore, useIOStore, IOContext } from "./provider";

--- a/src/react/packages/funcnodes-react-flow/src/features/nodes/rf-node-types.ts
+++ b/src/react/packages/funcnodes-react-flow/src/features/nodes/rf-node-types.ts
@@ -1,6 +1,22 @@
 import { NodeGroup } from "@/groups";
 import { Node as RFNode } from "@xyflow/react";
 
+export interface CollapsedGroupIO {
+  handleId: string;
+  nodeId: string;
+  ioId: string;
+  ioName: string;
+  nodeName: string;
+  direction: "input" | "output";
+  connectionCount: number;
+  type?: string;
+}
+
+export interface CollapsedGroupVisualState {
+  inputs: CollapsedGroupIO[];
+  outputs: CollapsedGroupIO[];
+}
+
 interface FuncNodesRFNodeData {
   groupID?: string;
   [key: string]: unknown;
@@ -12,6 +28,8 @@ interface FuncNodesRFNode extends RFNode {
 export interface GroupRFNodeData extends FuncNodesRFNodeData {
   group: NodeGroup;
   id: string;
+  collapsed?: boolean;
+  collapsedInfo?: CollapsedGroupVisualState;
 }
 
 export interface GroupRFNode extends FuncNodesRFNode {


### PR DESCRIPTION
## Summary
- add collapsed group bookkeeping in the node space manager so child nodes are hidden, IOs are exposed, and proxy edges mirror external connections
- resolve collapsed group handles when connecting edges to map back to the original node IOs
- update the default group component and styling to toggle collapse state and render aggregated inputs and outputs

## Testing
- `yarn test --watch=false` *(fails: multiple existing vitest suites such as ConsoleLogger and SizeContextContainer)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0388cd0c8332b7f2117e2bc6ac37